### PR TITLE
fix: include .nodesecurerc schema in the TypeScript compilation process

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,13 +7,13 @@
     "module": "ES2020",
     "moduleResolution": "node",
     "esModuleInterop": true,
-    "resolveJsonModule": false,
+    "resolveJsonModule": true,
     "skipDefaultLibCheck": true,
     "forceConsistentCasingInFileNames": true,
     "sourceMap": true,
     "rootDir": "./src",
     "types": ["node", "mocha"]
   },
-  "include": ["src"],
+  "include": ["src", "src/schema/nodesecurerc.json"],
   "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
Related to #5

To test it, run `npm run build` and observe that `/dist` now includes the schema.