### PR TITLE
add NodeSecure Report configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,5 @@ dist
 
 # TernJS port file
 .tern-port
+
+temp/

--- a/package-lock.json
+++ b/package-lock.json
@@ -876,6 +876,21 @@
       "integrity": "sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ==",
       "dev": true
     },
+    "@types/lodash": {
+      "version": "4.14.180",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.180.tgz",
+      "integrity": "sha512-XOKXa1KIxtNXgASAnwj7cnttJxS4fksBRywK/9LzRV5YxrF80BXZIGeQSuoESQ/VkUj30Ae0+YcuHc15wJCB2g==",
+      "dev": true
+    },
+    "@types/lodash.merge": {
+      "version": "4.6.6",
+      "resolved": "https://registry.npmjs.org/@types/lodash.merge/-/lodash.merge-4.6.6.tgz",
+      "integrity": "sha512-IB90krzMf7YpfgP3u/EvZEdXVvm4e3gJbUvh5ieuI+o+XqiNEt6fCzqNRaiLlPVScLI59RxIGZMQ3+Ko/DJ8vQ==",
+      "dev": true,
+      "requires": {
+        "@types/lodash": "*"
+      }
+    },
     "@types/minimist": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.2.tgz",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   "devDependencies": {
     "@nodesecure/eslint-config": "^1.3.1",
     "@types/chai": "^4.3.0",
+    "@types/lodash.merge": "^4.6.6",
     "@types/mocha": "^9.1.0",
     "@types/node": "^17.0.13",
     "@types/zen-observable": "^0.8.3",
@@ -44,6 +45,7 @@
     "c8": "^7.11.0",
     "chai": "^4.3.6",
     "eslint": "^8.7.0",
+    "lodash.merge": "^4.6.2",
     "mocha": "^9.2.0",
     "tape": "^5.5.0",
     "ts-node": "^10.4.0",

--- a/src/projects/ci.ts
+++ b/src/projects/ci.ts
@@ -1,0 +1,36 @@
+// Import Types Dependencies
+import * as jsxray from "@nodesecure/js-x-ray";
+
+/**
+ * Configuration dedicated for NodeSecure CI (or nsci)
+ * @see https://github.com/NodeSecure/ci
+ * @see https://github.com/NodeSecure/ci-action
+ */
+export interface CiConfiguration {
+  /**
+   * List of enabled reporters
+   * @see https://github.com/NodeSecure/ci#reporters
+   */
+  reporters?: ("console" | "html")[];
+  vulnerabilities?: {
+    severity?: "medium" | "high" | "critical" | "all"
+  };
+  /**
+   * JS-X-Ray warnings configuration
+   * @see https://github.com/NodeSecure/js-x-ray#warnings-legends-v20
+   */
+  warnings?: CiWarnings | Record<jsxray.kindWithValue | "unsafe-import", CiWarnings>;
+}
+export type CiWarnings = "off" | "error" | "warning";
+
+export function generateCIConfiguration(): { ci: CiConfiguration } {
+  const ci: CiConfiguration = {
+    reporters: ["console"],
+    vulnerabilities: {
+      severity: "medium"
+    },
+    warnings: "error"
+  };
+
+  return { ci };
+}

--- a/src/projects/report.ts
+++ b/src/projects/report.ts
@@ -1,0 +1,102 @@
+
+/**
+ * Configuration dedicated for NodeSecure Report
+ * @see https://github.com/NodeSecure/report
+ */
+export interface ReportConfiguration {
+  /**
+   * @default `light`
+   */
+  theme?: "light" | "dark";
+  title: string;
+  /**
+   * URL to a logo to show on the final HTML/PDF Report
+   */
+  logoUrl: string;
+  /**
+   * Show/categorize internal dependencies as transitive
+   * @default false
+   */
+  includeTransitiveInternal?: boolean;
+  npm?: {
+    /**
+     * NPM organization prefix starting with @
+     * @example `@nodesecure`
+     */
+    organizationPrefix: string;
+    packages: string[];
+  },
+  git?: {
+    /**
+     * GitHub organization URL
+     * @example `https://github.com/NodeSecure`
+     */
+    organizationUrl: string;
+    /**
+     * List of repositories (name are enough, no need to provide .git url or any equivalent)
+     */
+    repositories: string[];
+  },
+  /**
+   * @default html,pdf
+   */
+  reporters?: ("html" | "pdf")[];
+  charts?: ReportChart[];
+}
+
+export interface ReportChart {
+  /**
+   * List of available charts.
+   */
+  name: "Extensions" | "Licenses" | "Warnings" | "Flags";
+  /**
+   * @default true
+   */
+  display?: boolean;
+  /**
+   * Chart.js chart type.
+   *
+   * @see https://www.chartjs.org/docs/latest/charts
+   * @default `bar`
+   */
+  type?: "bar" | "horizontalBar" | "polarArea" | "doughnut";
+  /**
+   * D3 Interpolation color. Will be picked randomly by default if not provided.
+   * @see https://github.com/d3/d3-scale-chromatic/blob/main/README.md
+   */
+  interpolation?: string;
+}
+
+export function generateReportConfiguration(): { report: Partial<ReportConfiguration> } {
+  const report: Partial<ReportConfiguration> = {
+    theme: "light" as const,
+    includeTransitiveInternal: false,
+    reporters: ["html", "pdf"],
+    charts: [
+      {
+        name: "Extensions" as const,
+        display: true,
+        interpolation: "d3.interpolateRainbow"
+      },
+      {
+        name: "Licenses" as const,
+        display: true,
+        interpolation: "d3.interpolateCool"
+      },
+      {
+        name: "Warnings" as const,
+        display: true,
+        type: "horizontalBar" as const,
+        interpolation: "d3.interpolateInferno"
+      },
+      {
+        name: "Flags" as const,
+        display: true,
+        type: "horizontalBar" as const,
+        interpolation: "d3.interpolateSinebow"
+      }
+    ]
+  };
+
+  return { report };
+}

--- a/src/rc.ts
+++ b/src/rc.ts
@@ -1,10 +1,10 @@
 // Import Types Dependencies
 import i18n from "@nodesecure/i18n";
 import * as vuln from "@nodesecure/vuln";
-import * as jsxray from "@nodesecure/js-x-ray";
 
 // Import Internal Dependencies
 import { readJSONSync } from "./utils/index.js";
+import { generateCIConfiguration, CiConfiguration, CiWarnings } from "./projects/ci.js";
 
 // CONSTANTS
 export const JSONSchema = readJSONSync("./schema/nodesecurerc.json", import.meta.url);
@@ -31,40 +31,6 @@ export interface RC {
   ci?: CiConfiguration;
 }
 
-/**
- * Configuration dedicated for NodeSecure CI (or nsci)
- * @see https://github.com/NodeSecure/ci
- * @see https://github.com/NodeSecure/ci-action
- */
-export interface CiConfiguration {
-  /**
-   * List of enabled reporters
-   * @see https://github.com/NodeSecure/ci#reporters
-   */
-  reporters?: ("console" | "html")[];
-  vulnerabilities?: {
-    severity?: "medium" | "high" | "critical" | "all"
-  };
-  /**
-   * JS-X-Ray warnings configuration
-   * @see https://github.com/NodeSecure/js-x-ray#warnings-legends-v20
-   */
-  warnings?: CiWarnings | Record<jsxray.kindWithValue | "unsafe-import", CiWarnings>;
-}
-export type CiWarnings = "off" | "error" | "warning";
-
-export function generateCIConfiguration(): { ci: CiConfiguration } {
-  const ci: CiConfiguration = {
-    reporters: ["console"],
-    vulnerabilities: {
-      severity: "medium"
-    },
-    warnings: "error"
-  };
-
-  return { ci };
-}
-
 export type RCGenerationMode = "minimal" | "ci" | "complete";
 
 /**
@@ -87,3 +53,9 @@ export function generateDefaultRC(mode: RCGenerationMode | RCGenerationMode[] = 
     complete || modes.has("ci") ? generateCIConfiguration() : {}
   );
 }
+
+export {
+  CiConfiguration,
+  CiWarnings,
+  generateCIConfiguration
+};

--- a/src/rc.ts
+++ b/src/rc.ts
@@ -3,11 +3,12 @@ import i18n from "@nodesecure/i18n";
 import * as vuln from "@nodesecure/vuln";
 
 // Import Internal Dependencies
-import { readJSONSync } from "./utils/index.js";
+import { loadJSONSchemaSync } from "./schema/loader.js";
 import { generateCIConfiguration, CiConfiguration, CiWarnings } from "./projects/ci.js";
+import { generateReportConfiguration, ReportConfiguration, ReportChart } from "./projects/report.js";
 
 // CONSTANTS
-export const JSONSchema = readJSONSync("./schema/nodesecurerc.json", import.meta.url);
+export const JSONSchema = loadJSONSchemaSync();
 
 export interface RC {
   /** version of the rc package used to generate the nodesecurerc file */
@@ -29,14 +30,16 @@ export interface RC {
   strategy?: vuln.Strategy.Kind;
   /** NodeSecure ci Object configuration */
   ci?: CiConfiguration;
+  /** NodeSecure report Object configuration */
+  report?: ReportConfiguration;
 }
 
-export type RCGenerationMode = "minimal" | "ci" | "complete";
+export type RCGenerationMode = "minimal" | "ci" | "report" | "complete";
 
 /**
  * @example
  * generateDefaultRC("complete");
- * generateDefaultRC(["ci", "scanner"]); // minimal + ci + scanner
+ * generateDefaultRC(["ci", "report"]); // minimal + ci + report
  */
 export function generateDefaultRC(mode: RCGenerationMode | RCGenerationMode[] = "minimal"): RC {
   const modes = new Set(typeof mode === "string" ? [mode] : mode);
@@ -50,12 +53,17 @@ export function generateDefaultRC(mode: RCGenerationMode | RCGenerationMode[] = 
 
   return Object.assign(
     minimalRC,
-    complete || modes.has("ci") ? generateCIConfiguration() : {}
+    complete || modes.has("ci") ? generateCIConfiguration() : {},
+    complete || modes.has("report") ? generateReportConfiguration() : {}
   );
 }
 
 export {
+  generateCIConfiguration,
   CiConfiguration,
   CiWarnings,
-  generateCIConfiguration
+
+  generateReportConfiguration,
+  ReportConfiguration,
+  ReportChart
 };

--- a/src/schema/defs/ci.json
+++ b/src/schema/defs/ci.json
@@ -1,0 +1,58 @@
+{
+  "type": "object",
+  "properties": {
+    "reporters": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "enum": [
+          "html",
+          "console"
+        ]
+      },
+      "default": [
+        "console"
+      ]
+    },
+    "vulnerabilities": {
+      "type": "object",
+      "properties": {
+        "severity": {
+          "type": "string",
+          "enum": [
+            "medium",
+            "high",
+            "critical",
+            "all"
+          ],
+          "default": "all"
+        }
+      },
+      "additionalProperties": false
+    },
+    "warnings": {
+      "default": "off",
+      "description": "JS-X-Ray warnings configuration",
+      "oneOf": [
+        {
+          "$ref": "#/$defs/ciWarnings"
+        },
+        {
+          "type": "object",
+          "minProperties": 1,
+          "patternProperties": {
+            "^[A-Za-z-]+$": {
+              "$ref": "#/$defs/ciWarnings"
+            }
+          }
+        }
+      ]
+    }
+  },
+  "required": [
+    "reporters",
+    "warnings"
+  ],
+  "additionalProperties": false
+}

--- a/src/schema/defs/ciWarnings.json
+++ b/src/schema/defs/ciWarnings.json
@@ -1,0 +1,8 @@
+{
+  "type": "string",
+  "enum": [
+    "off",
+    "error",
+    "warning"
+  ]
+}

--- a/src/schema/defs/report.json
+++ b/src/schema/defs/report.json
@@ -1,0 +1,98 @@
+{
+  "title": "Report configuration",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "title",
+    "logoUrl"
+  ],
+  "properties": {
+    "theme": {
+      "type": "string",
+      "enum": [
+        "light",
+        "dark"
+      ],
+      "default": "light"
+    },
+    "title": {
+      "type": "string",
+      "description": "Report title",
+      "default": "Default report title"
+    },
+    "logoUrl": {
+      "type": "string",
+      "description": "Logo",
+      "default": "https://avatars0.githubusercontent.com/u/29552883?s=200&v=4"
+    },
+    "includeTransitiveInternal": {
+      "type": "boolean",
+      "default": false,
+      "description": "Show/categorize internal dependencies as transitive"
+    },
+    "npm": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "organizationPrefix",
+        "packages"
+      ],
+      "properties": {
+        "organizationPrefix": {
+          "type": "string",
+          "description": "NPM organization prefix starting with @"
+        },
+        "packages": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "uniqueItems": true
+        }
+      }
+    },
+    "git": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "organizationUrl",
+        "repositories"
+      ],
+      "properties": {
+        "organizationUrl": {
+          "type": "string",
+          "description": "GitHub organization URL"
+        },
+        "repositories": {
+          "type": "array",
+          "description": "List of repositories (name are enough, no need to provide .git url or any equivalent)",
+          "items": {
+            "type": "string"
+          },
+          "uniqueItems": true
+        }
+      }
+    },
+    "reporters": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "enum": [
+          "html",
+          "pdf"
+        ]
+      },
+      "default": [
+        "html",
+        "pdf"
+      ]
+    },
+    "charts": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/reportChart"
+      }
+    }
+  }
+}

--- a/src/schema/defs/reportChart.json
+++ b/src/schema/defs/reportChart.json
@@ -1,0 +1,27 @@
+{
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "name"
+  ],
+  "properties": {
+    "name": {
+      "type": "string",
+      "enum": ["Extensions", "Licenses", "Warnings", "Flags"]
+    },
+    "display": {
+      "type": "boolean",
+      "default": true
+    },
+    "type": {
+      "type": "string",
+      "enum": ["bar", "horizontalBar", "polarArea", "doughnut"],
+      "default": "bar",
+      "description": "Chart.js chart type."
+    },
+    "interpolation": {
+      "type": "string",
+      "description": "D3.js chromatic interpolation set of colors"
+    }
+  }
+}

--- a/src/schema/loader.ts
+++ b/src/schema/loader.ts
@@ -1,0 +1,25 @@
+// Import Node.js Dependencies
+import { readdirSync } from "node:fs";
+import path from "node:path";
+
+// Import Internal Dependencies
+import { readJSONSync } from "../utils/index.js";
+
+// CONSTANTS
+const kDefsDirectory = new URL("./defs", import.meta.url);
+
+function loadJSONSchemaDefinition($defs: Record<string, any>, fileName: string) {
+  const defName = path.basename(fileName, ".json");
+  const jsonSchema = readJSONSync(`./defs/${fileName}`, import.meta.url);
+
+  return { ...$defs, [defName]: jsonSchema };
+}
+
+export function loadJSONSchemaSync() {
+  const mainSchema = readJSONSync("./nodesecurerc.json", import.meta.url);
+  const $defs = readdirSync(kDefsDirectory)
+    .filter((fileName) => path.extname(fileName) === ".json")
+    .reduce(loadJSONSchemaDefinition, {});
+
+  return Object.assign(mainSchema, { $defs });
+}

--- a/src/schema/nodesecurerc.json
+++ b/src/schema/nodesecurerc.json
@@ -7,68 +7,33 @@
     },
     "i18n": {
       "type": "string",
-      "enum": ["french", "english"],
+      "enum": [
+        "french",
+        "english"
+      ],
       "default": "english",
       "description": "Language to use for i18n"
     },
     "strategy": {
       "type": "string",
-      "enum": ["npm", "node", "snyk", "none"],
+      "enum": [
+        "npm",
+        "node",
+        "snyk",
+        "none"
+      ],
       "default": "npm",
       "description": "Vulnerability strategy to use"
     },
     "ci": {
       "$ref": "#/$defs/ci"
+    },
+    "report": {
+      "$ref": "#/$defs/report"
     }
   },
-  "required": ["version"],
-  "additionalProperties": false,
-  "$defs": {
-    "ci": {
-      "type": "object",
-      "properties": {
-        "reporters": {
-          "type": "array",
-          "minItems": 1,
-          "maxItems": 2,
-          "items": {
-            "type": "string",
-            "enum": ["html", "console"]
-          },
-          "default": ["console"]
-        },
-        "vulnerabilities": {
-          "type": "object",
-          "properties": {
-            "severity": {
-              "type": "string",
-              "enum": ["medium", "high", "critical", "all"],
-              "default": "all"
-            }
-          },
-          "additionalProperties": false
-        },
-        "warnings": {
-          "default": "off",
-          "description": "JS-X-Ray warnings configuration",
-          "oneOf": [
-            { "$ref": "#/$defs/ciWarnings" },
-            {
-              "type": "object",
-              "minProperties": 1,
-              "patternProperties": {
-                "^[A-Za-z-]+$": { "$ref": "#/$defs/ciWarnings" }
-              }
-            }
-          ]
-        }
-      },
-      "required": ["reporters", "warnings"],
-      "additionalProperties": false
-    },
-    "ciWarnings": {
-      "type": "string",
-      "enum": ["off", "error", "warning"]
-    }
-  }
+  "required": [
+    "version"
+  ],
+  "additionalProperties": false
 }

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -6,6 +6,7 @@ import { fileURLToPath } from "node:url";
 // Import Third-party Dependencies
 import { expect } from "chai";
 import Ajv from "ajv";
+import merge from "lodash.merge";
 
 // Import Internal Dependencies
 import * as RC from "../src/index.js";
@@ -23,12 +24,25 @@ describe("CONSTANTS", () => {
 });
 
 describe("JSON Schema", () => {
+  const kDummyPartialMandatoryRC: Partial<RC.RC> = {
+    report: {
+      title: "hello report",
+      logoUrl: "foobar"
+    }
+  };
+
   it("should export a valid JSON Schema", () => {
     const ajv = new Ajv();
     const validate = ajv.compile(RC.JSONSchema);
 
     expect(validate(generateDefaultRC())).equal(true);
-    expect(validate(generateDefaultRC("complete"))).equal(true);
+
+    const completeRC = merge(
+      generateDefaultRC("complete"),
+      kDummyPartialMandatoryRC
+    );
+    expect(validate(completeRC)).equal(true);
+
     expect(validate({ foo: "bar" })).equal(false);
   });
 

--- a/test/rc.spec.ts
+++ b/test/rc.spec.ts
@@ -4,11 +4,13 @@ import { expect } from "chai";
 // Import Internal Dependencies
 import {
   generateDefaultRC,
-  generateCIConfiguration
+  generateCIConfiguration,
+  generateReportConfiguration
 } from "../src/rc.js";
 
-describe("generate RC (internals)", () => {
-  it("should generate a RC with generation mode set to 'ci'", () => {
+describe("generateDefaultRC (internals)", () => {
+  it(`should generate a RC with argument 'mode' equal 'ci' and
+  then return an RC combining Default + CIConfiguration`, () => {
     const rc = generateDefaultRC("ci");
     const expectedResult = Object.assign(
       generateDefaultRC(),
@@ -18,11 +20,24 @@ describe("generate RC (internals)", () => {
     expect(rc).deep.equal(expectedResult);
   });
 
-  it("should generate a RC with generation mode set to Array ['complete']", () => {
+  it(`should generate a RC with argument 'mode' equal 'report' and
+  then return an RC combining Default + ReportConfiguration`, () => {
+    const rc = generateDefaultRC("report");
+    const expectedResult = Object.assign(
+      generateDefaultRC(),
+      generateReportConfiguration()
+    );
+
+    expect(rc).deep.equal(expectedResult);
+  });
+
+  it(`should generate a RC with argument 'mode' equal an Array ['complete'] and
+  then return an RC combining all kind of available configurations internally`, () => {
     const rc = generateDefaultRC(["complete"]);
     const expectedResult = Object.assign(
       generateDefaultRC(),
-      generateCIConfiguration()
+      generateCIConfiguration(),
+      generateReportConfiguration()
     );
 
     expect(rc).deep.equal(expectedResult);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,6 +14,6 @@
     "rootDir": "./src",
     "types": ["node", "mocha"]
   },
-  "include": ["src", "src/schema/nodesecurerc.json"],
+  "include": ["src", "src/schema/**/*.json"],
   "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
This PR implement a first draft of configuration for the NodeSecure report project.

I made some modifications to allow a better integration of the future configuration:
- Split types and interfaces in `./src/projects`
- Split JSON Schema defs (it now work with a loader helpers).